### PR TITLE
V0.41.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   # Intervals is not available on s390x
-  skip: true  # [py<36 and s390x]
+  skip: true  # [py<36 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  # Intervals is not available on s390x
+  skip: true  # [py<36 and s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
+  skip: true  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - sqlalchemy
   run:
     - python
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.37.8" %}
+{% set version = "0.41.0" %}
 
 package:
   name: sqlalchemy-utils
@@ -7,7 +7,7 @@ package:
 source:
   # The source url changed for  0.37.*
   url: https://pypi.io/packages/source/S/SQLAlchemy-Utils/SQLAlchemy-Utils-{{ version }}.tar.gz
-  sha256: a6aaee154f798be4e479af0ceffaa5034d35fcf6f40707c0947d21bde64e05e5
+  sha256: 894cce255eea0bcc4fdcff628af30219d24a325526011586dd7f1e3d9dfebba0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,12 +20,13 @@ requirements:
     - pip
     - wheel
     - setuptools
+    - sqlalchemy 1.4.39
+    - importlib_metadata 6.0.0 # [py<38]
   run:
     - python
     - six
     - sqlalchemy >=1.0
     # extras
-    - anyjson >=0.3.3
     - babel >=1.3
     - arrow >=0.3.4
     - pendulum >=2.0.5
@@ -55,6 +56,9 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   summary: Various utility functions for SQLAlchemy
+  description: |
+    SQLAlchemy-Utils provides custom data types
+    and various utility functions for SQLAlchemy.
   dev_url: https://github.com/kvesteri/sqlalchemy-utils
   doc_url: https://sqlalchemy-utils.readthedocs.io
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,12 +21,11 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - sqlalchemy 1.4.39
-    - importlib_metadata 6.0.0 # [py<38]
+    - sqlalchemy
   run:
     - python
     - six
-    - sqlalchemy >=1.0
+    - sqlalchemy >=1.3
     # extras
     - babel >=1.3
     - arrow >=0.3.4
@@ -38,6 +37,8 @@ requirements:
     - python-dateutil
     - furl >=0.4.1
     - cryptography >=0.6
+    - importlib_metadata  # [py<38]
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.41.0" %}
+{% set version = "0.41.1" %}
 
 package:
   name: sqlalchemy-utils
@@ -7,7 +7,7 @@ package:
 source:
   # The source url changed for  0.37.*
   url: https://pypi.io/packages/source/S/SQLAlchemy-Utils/SQLAlchemy-Utils-{{ version }}.tar.gz
-  sha256: 894cce255eea0bcc4fdcff628af30219d24a325526011586dd7f1e3d9dfebba0
+  sha256: a2181bff01eeb84479e38571d2c0718eb52042f9afd8c194d0d02877e84b7d74
 
 build:
   number: 0


### PR DESCRIPTION
[Upstream](https://github.com/kvesteri/sqlalchemy-utils)
[Changelog](https://github.com/kvesteri/sqlalchemy-utils/releases)

### Actions
- Updated version and sha256
- Updated dependencies
- Linter fixes

### Notes
- Skipping `s390x` since `intervals` is not available