### PR TITLE
sqlalchemy-utils 0.41.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/orderedmultidict-feedstock/pr2/1402294
   - https://staging.continuum.io/prefect/fs/infinity-feedstock/pr2/0fcf2ac
-  - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr2/d9dde58
+  - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr3/d9dde58

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/orderedmultidict-feedstock/pr2/1402294
+  - https://staging.continuum.io/prefect/fs/infinity-feedstock/pr2/0fcf2ac
+  - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr2/d9dde58

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/orderedmultidict-feedstock/pr2/1402294
+  - https://staging.continuum.io/prefect/fs/infinity-feedstock/pr2/0fcf2ac
   - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr3/d9dde58

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,3 @@
 channels:
   - https://staging.continuum.io/prefect/fs/orderedmultidict-feedstock/pr2/1402294
-  - https://staging.continuum.io/prefect/fs/infinity-feedstock/pr2/0fcf2ac
   - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr3/d9dde58

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/orderedmultidict-feedstock/pr2/1402294
-  - https://staging.continuum.io/prefect/fs/infinity-feedstock/pr2/0fcf2ac
-  - https://staging.continuum.io/prefect/fs/intervals-feedstock/pr3/d9dde58

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - setuptools
   run:
     - python
-    - six
     - sqlalchemy >=1.3
     # extras
     - babel >=1.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.41.1" %}
+{% set version = "0.41.2" %}
 
 package:
   name: sqlalchemy-utils
@@ -7,12 +7,12 @@ package:
 source:
   # The source url changed for  0.37.*
   url: https://pypi.io/packages/source/S/SQLAlchemy-Utils/SQLAlchemy-Utils-{{ version }}.tar.gz
-  sha256: a2181bff01eeb84479e38571d2c0718eb52042f9afd8c194d0d02877e84b7d74
+  sha256: bc599c8c3b3319e53ce6c5c3c471120bd325d0071fb6f38a10e924e3d07b9990
 
 build:
   number: 0
   # Intervals is not available on s390x
-  skip: true  # [py<36 or s390x]
+  skip: true  # [py<37 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4686](https://anaconda.atlassian.net/browse/PKG-4686)
- [Upstream repository](https://github.com/kvesteri/sqlalchemy-utils/tree/0.42.2)
- [Upstream changelog/diff](https://github.com/kvesteri/sqlalchemy-utils/blob/0.42.2/CHANGES.rst)

### Explanation of changes:

- Update version and python version skip
- Update dependencies


[PKG-4686]: https://anaconda.atlassian.net/browse/PKG-4686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ